### PR TITLE
Pause simulator at end of match

### DIFF
--- a/controllers/rcj_soccer_referee_supervisor/rcj_soccer_referee_supervisor.py
+++ b/controllers/rcj_soccer_referee_supervisor/rcj_soccer_referee_supervisor.py
@@ -8,3 +8,6 @@ while referee.step(TIME_STEP) != -1:
 
     if not referee.tick():
         break
+
+# When end of match, pause simulator immediately
+referee.simulationSetMode(referee.SIMULATION_MODE_PAUSE)


### PR DESCRIPTION
Since after end of the match simulator is still working and consumpting resources significantly at FAST mode.
Hence pause the simulator after the match and prevent it. 
