### PR TITLE
logs: Change suffix from JSON to JSONL

### DIFF
--- a/controllers/rcj_soccer_referee_supervisor/rcj_soccer_referee_supervisor.py
+++ b/controllers/rcj_soccer_referee_supervisor/rcj_soccer_referee_supervisor.py
@@ -20,7 +20,7 @@ def reflog_path(directory: Path,
     if not directory.exists():
         directory.mkdir(parents=True, exist_ok=True)
 
-    p = directory / Path(f'{team_blue}_vs_{team_yellow}-{now_str}.json')
+    p = directory / Path(f'{team_blue}_vs_{team_yellow}-{now_str}.jsonl')
     return p
 
 

--- a/controllers/rcj_soccer_referee_supervisor/referee/referee.py
+++ b/controllers/rcj_soccer_referee_supervisor/referee/referee.py
@@ -72,7 +72,8 @@ class RCJSoccerReferee(RCJSoccerSupervisor):
                 msg=f"The match ({self.match_time}s) has started",
                 payload={
                     "score_yellow": self.score_yellow,
-                    "score_blue": self.score_blue
+                    "score_blue": self.score_blue,
+                    "total_match_time": self.match_time
                 }
             )
 


### PR DESCRIPTION
* To better represent what the file actually contains, change the suffix
  of the log output file from JSON to JSONL

* Add full length of match to the payload sent with the MATCH_STARTED
  event.

Signed-off-by: mr.Shu <mr@shu.io>